### PR TITLE
Use latest tools.reader version to fix dependency conflict introduced by Timbre.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,9 @@
                  [clj-http "3.10.0"]
                  [hiccup "1.0.5"]
                  [com.taoensso/timbre "4.10.0"]
+                 ;; use latest tools.reader to fix issues with timbre using an old version
+                 ;; see https://github.com/ptaoussanis/timbre/issues/263
+                 [org.clojure/tools.reader "1.3.2"]
                  [cheshire "5.8.1"]]
   :main ^:skip-aot codescene-ci-cd.core
   :uberjar-name "codescene-ci-cd.standalone.jar"


### PR DESCRIPTION
See https://github.com/ptaoussanis/timbre/issues/263

Manifested as:
```
1. Caused by java.lang.IllegalAccessError
   reader-error does not exist
```

This probably happens only during development when you use tools depending on more modern tools.reader version.