### PR TITLE
Update project's dependencies to fix clj-http issue and make this work for Java 9+

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,11 @@
                  ;; use latest tools.reader to fix issues with timbre using an old version
                  ;; see https://github.com/ptaoussanis/timbre/issues/263
                  [org.clojure/tools.reader "1.3.2"]
-                 [cheshire "5.8.1"]]
+                 [cheshire "5.8.1"]
+                 ;; explicit dependency on jaxb-api for java 9+ compatibility
+                 ;; see https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j
+                 [javax.xml.bind/jaxb-api "2.3.0"]
+                 ]
   :main ^:skip-aot codescene-ci-cd.core
   :uberjar-name "codescene-ci-cd.standalone.jar"
   :profiles {:uberjar {:aot :all}})

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [ring/ring-jetty-adapter "1.7.1"]
                  [ring/ring-json "0.4.0"]
                  [ring/ring-codec "1.1.2"]
-                 [clj-http "3.10.0"]
+                 [clj-http "3.9.0"]
                  [hiccup "1.0.5"]
                  [com.taoensso/timbre "4.10.0"]
                  ;; use latest tools.reader to fix issues with timbre using an old version


### PR DESCRIPTION
- clj-http downgraded to fix the JSON serialization issue: https://github.com/dakrone/clj-http/issues/489
- explicit jaxb-api dependency added to make this work with JDK 9+.