### PR TITLE
Simple async execution via `future` and logging internal errors.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,6 +20,9 @@
                  ;; explicit dependency on jaxb-api for java 9+ compatibility
                  ;; see https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j
                  [javax.xml.bind/jaxb-api "2.3.0"]
+                 ;; try to fix Unexpected error (NoClassDefFoundError) macroexpanding GET at (src/codescene_ci_cd/server.clj:26:5).
+                 ;;   instaparse/core/Parser$reify__17365
+                 [instaparse "1.4.10"]
                  ]
   :main ^:skip-aot codescene-ci-cd.core
   :uberjar-name "codescene-ci-cd.standalone.jar"

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,6 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/tools.cli "0.4.2"]
                  [org.clojure/data.json "0.2.6"]
-                 [org.clojure/core.async "0.4.500"]
                  [compojure "1.6.1"]
                  [ring/ring-defaults "0.3.2"]
                  [ring/ring-jetty-adapter "1.7.1"]

--- a/src/codescene_ci_cd/core.clj
+++ b/src/codescene_ci_cd/core.clj
@@ -125,10 +125,12 @@
   [args]
   (let [{:keys [options arguments errors summary]} (cli/parse-opts args cli-options)]
     (cond
-      ;; run as a service
-      (not (seq args)) (server/start-server {:join? true})
+      ;; run as a long-running service
+      (not (seq args)) {:service? true}
+      
       ;; help => exit OK with usage summary
       (:help options) {:exit-message (usage summary) :ok? true}
+
       ;; errors => exit with description of errors
       errors {:exit-message (error-msg errors)}
       :else (let [validation-errors (validate-options options)]
@@ -170,9 +172,15 @@
       [(:pass-on-failed-analysis options) (str "CodeScene-CI/CD couldn't perform the delta analysis:" (utils/ex->str e))])))
 
 (defn -main [& args]
-  (let [{:keys [options exit-message ok?]} (parse-args args)]
-    (if exit-message
+  (let [{:keys [options exit-message ok? service?]} (parse-args args)]
+    (cond
+      service?
+      (server/start-server {:join? true})
+
+      exit-message
       (exit ok? exit-message)
+
+      :else
       (let [[ok? exit-message] (run-analysis-and-handle-result options)]
         (exit ok? exit-message)))))
 
@@ -201,3 +209,4 @@
 
   ;; end
   )
+

--- a/src/codescene_ci_cd/github_validation.clj
+++ b/src/codescene_ci_cd/github_validation.clj
@@ -1,7 +1,6 @@
 (ns codescene-ci-cd.github-validation
   (:require
-    [taoensso.timbre :as log]
-    [clojure.java.io :as io])
+    [taoensso.timbre :as log])
   (:import org.apache.commons.codec.binary.Hex
            javax.crypto.Mac;
            javax.crypto.spec.SecretKeySpec


### PR DESCRIPTION
## Use `future` to run analysis asynchronously.

No need to use core-async (too heavyweight tool for the job).

## Wrap internal error in request handler.

Before we wouldn't see anything useful in logs and response body.
Now we get at least the error message in the response body
and full stacktrace in the log.
